### PR TITLE
feat: add ancestor tree above file/folder list

### DIFF
--- a/drive-app/app/Http/Controllers/FileController.php
+++ b/drive-app/app/Http/Controllers/FileController.php
@@ -13,9 +13,15 @@ use App\Models\File;
 
 class FileController extends Controller
 {
-    public function myFiles()
+    public function myFiles(string $folder = null)
     {
-        $folder = $this->getRoot();
+        if ($folder) {
+            $folder = File::query()->where('created_by', Auth::id())->where('path', $folder)->firstOrFail();
+        }
+
+        if (!$folder) {
+            $folder = $this->getRoot();
+        }
 
         $files = File::query()
             ->where('parent_id', $folder->id)
@@ -26,7 +32,11 @@ class FileController extends Controller
 
         $files = FileResource::collection($files);
 
-        return Inertia::render('MyFiles', compact('files'));
+        $ancestors = FileResource::collection([...$folder->ancestors, $folder]);
+
+        $folder = new FileResource($folder);
+
+        return Inertia::render('MyFiles', compact('files', 'folder', 'ancestors'));
     }
 
     public function createFolder(StoreFolderRequest $request)

--- a/drive-app/resources/js/Components/app/CreateFolderModal.vue
+++ b/drive-app/resources/js/Components/app/CreateFolderModal.vue
@@ -42,8 +42,11 @@
     import {nextTick, ref} from "vue";
 
     const form = useForm({
-        name: ''
+        name: '',
+        parent_id: null
     })
+
+    const page = usePage()
 
     const folderNameInput = ref(null)
 
@@ -64,6 +67,7 @@
     }
 
     function createFolder() {
+        form.parent_id = page.props.folder.id;
         form.post(route('folder.create'), {
             preserveScroll: true,
             onSuccess: () => {

--- a/drive-app/resources/js/Pages/MyFiles.vue
+++ b/drive-app/resources/js/Pages/MyFiles.vue
@@ -1,13 +1,46 @@
 <script setup>
+    import {Link, router, useForm, usePage} from "@inertiajs/vue3";
     import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
 
     const {files} = defineProps({
-        files: Object
+        files: Object,
+        folder: Object,
+        ancestors: Array
     });
+
+    function openFolder(file) {
+        if(!file.is_folder) {
+            return;
+        }
+
+        router.visit(route('myFiles', {folder: file.path}))
+    }
 </script>
 
 <template>
     <AuthenticatedLayout>
+        <nav class="flex items-center justify-between p-1 mb-3">
+            <ol class="inline-flex items-center space-x-1 md:space-x-3">
+                <li v-for="ans of ancestors.data" :key="ans.id" class="inline-flex items-center">
+                    <Link v-if="!ans.parent_id" :href="route('myFiles')"
+                        class="inline-flex items-center text-sm font-medium text-gray-700 hover:text-blue-600 dark:text-gray-400 dark:hover:text-white">
+                        My Files
+                    </Link>
+                    <div v-else class="flex items-center">
+                        <svg aria-hidden="true" class="w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20"
+                             xmlns="http://www.w3.org/2000/svg">
+                            <path fill-rule="evenodd"
+                                  d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                                  clip-rule="evenodd"></path>
+                        </svg>
+                        <Link :href="route('myFiles', {folder: ans.path})"
+                              class="ml-1 text-sm font-medium text-gray-700 hover:text-blue-600 md:ml-2 dark:text-gray-400 dark:hover:text-white">
+                            {{ ans.name }}
+                        </Link>
+                    </div>
+                </li>
+            </ol>
+        </nav>
         <table class="min-w-full">
             <thead class="bg-gray-100 border-b">
                 <tr>
@@ -26,7 +59,8 @@
                 </tr>
             </thead>
             <tbody>
-                <tr v-for="file of files.data" :key="file.id" class="bg-white border-b transition duration-300 ease-in-out hover:bg-gray-100">
+                <tr v-for="file of files.data" :key="file.id"
+                    class="bg-white border-b transition duration-300 ease-in-out hover:bg-gray-100 cursor-pointer" @dblclick="openFolder(file)">
                     <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
                         {{file.name}}
                     </td>

--- a/drive-app/routes/web.php
+++ b/drive-app/routes/web.php
@@ -17,7 +17,9 @@ Route::get('/', function () {
 Route::controller(\App\Http\Controllers\FileController::class)
     ->middleware(['auth','verified'])
     ->group(function () {
-        Route::get('/my-files', 'myFiles')->name('myFiles');
+        Route::get('/my-files/{folder?}', 'myFiles')
+            ->where('folder','(.*)')
+            ->name('myFiles');
         Route::post('/folder/create', 'createFolder')->name('folder.create');
     });
 


### PR DESCRIPTION
This change adds an ancestor tree at the top of the files/folder table. 

This is a nested tree that shows the user which folder they are in as well as if the folder is inside another folder. 