### PR TITLE
fix: correct errors related to the creation of nested folders / ancestor records

### DIFF
--- a/drive-app/app/Http/Requests/StoreFolderRequest.php
+++ b/drive-app/app/Http/Requests/StoreFolderRequest.php
@@ -31,4 +31,3 @@ class StoreFolderRequest extends ParentIdBaseRequest
         ];
     }
 }
-

--- a/drive-app/app/Models/File.php
+++ b/drive-app/app/Models/File.php
@@ -3,13 +3,15 @@
 namespace App\Models;
 
 use App\Traits\HasCreatorAndUpdater;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Kalnoy\Nestedset\NodeTrait;
 
 class File extends Model
@@ -49,8 +51,8 @@ class File extends Model
     {
         parent::boot();
 
-        static::creating(function($model) {
-            if($model->parent) {
+        static::creating(function ($model) {
+            if (!$model->parent) {
                 return;
             }
             $model->path = ( !$model->parent->isRoot() ? $model->parent->path . '/' : '' ) . Str::slug($model->name);

--- a/drive-app/resources/js/Components/app/CreateFolderModal.vue
+++ b/drive-app/resources/js/Components/app/CreateFolderModal.vue
@@ -67,7 +67,7 @@
     }
 
     function createFolder() {
-        form.parent_id = page.props.folder.id;
+        form.parent_id = page.props.folder.data.id;
         form.post(route('folder.create'), {
             preserveScroll: true,
             onSuccess: () => {

--- a/drive-app/resources/js/Pages/MyFiles.vue
+++ b/drive-app/resources/js/Pages/MyFiles.vue
@@ -1,4 +1,5 @@
 <script setup>
+    import {HomeIcon} from '@heroicons/vue/20/solid'
     import {Link, router, useForm, usePage} from "@inertiajs/vue3";
     import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
 
@@ -12,7 +13,6 @@
         if(!file.is_folder) {
             return;
         }
-
         router.visit(route('myFiles', {folder: file.path}))
     }
 </script>
@@ -24,6 +24,7 @@
                 <li v-for="ans of ancestors.data" :key="ans.id" class="inline-flex items-center">
                     <Link v-if="!ans.parent_id" :href="route('myFiles')"
                         class="inline-flex items-center text-sm font-medium text-gray-700 hover:text-blue-600 dark:text-gray-400 dark:hover:text-white">
+                        <HomeIcon class="w-4 h-4" />&nbsp;
                         My Files
                     </Link>
                     <div v-else class="flex items-center">

--- a/drive-app/routes/web.php
+++ b/drive-app/routes/web.php
@@ -18,7 +18,7 @@ Route::controller(\App\Http\Controllers\FileController::class)
     ->middleware(['auth','verified'])
     ->group(function () {
         Route::get('/my-files/{folder?}', 'myFiles')
-            ->where('folder','(.*)')
+            ->where('folder', '(.*)')
             ->name('myFiles');
         Route::post('/folder/create', 'createFolder')->name('folder.create');
     });


### PR DESCRIPTION
This change fixes some reference errors related to the folder id as well as the parent check for the isRoot() function on the file model.

The purpose of these fixes is to ensure that nested folders can properly be created and are correctly referenced in the breadcrumb tree underneath the search bar. 

There is also a minor addition to the display where a home icon is displayed on the left side of the ancestor tree. 