### PR TITLE
feat: create the boilerplate for file upload / drop feature

### DIFF
--- a/drive-app/app/Http/Controllers/FileController.php
+++ b/drive-app/app/Http/Controllers/FileController.php
@@ -55,6 +55,12 @@ class FileController extends Controller
         $parent->appendNode($file);
     }
 
+    public function store(StoreFileRequest $request)
+    {
+        $data = $request->validated();
+        dd($data);
+    }
+
     private function getRoot()
     {
         return File::query()->whereIsRoot()->where('created_by', Auth::id())->firstOrFail();

--- a/drive-app/app/Http/Requests/StoreFileRequest.php
+++ b/drive-app/app/Http/Requests/StoreFileRequest.php
@@ -4,6 +4,8 @@ namespace App\Http\Requests;
 
 use App\Models\File;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 class StoreFileRequest extends ParentIdBaseRequest
 {
@@ -13,16 +15,18 @@ class StoreFileRequest extends ParentIdBaseRequest
             'files.*' => [
                 'required',
                 'file',
-                function($attribute, $value, $fail) {
-                    $file = File::query()->where('name', $value->getClientOriginalName())
-                                 ->where('created_by', Auth::id())
-                                 ->where('parent_id', $this->parent_id)
-                                 ->whereNull('deleted_at')
-                                 ->exists();
-                }
+                function ($attribute, $value, $fail) {
+                    if (!$this->folder_name) {
+                        $file = File::query()->where('name', $value->getClientOriginalName())
+                            ->where('created_by', Auth::id())
+                            ->where('parent_id', $this->parent_id)
+                            ->whereNull('deleted_at')
+                            ->exists();
 
-                if ($file) {
-                    $fail('File "' . $value->getClientOriginalName() . '" already exists.');
+                        if ($file) {
+                            $fail('File "' . $value->getClientOriginalName() . '" already exists.');
+                        }
+                    }
                 }
             ]
         ]);

--- a/drive-app/app/Http/Requests/StoreFileRequest.php
+++ b/drive-app/app/Http/Requests/StoreFileRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\File;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreFileRequest extends ParentIdBaseRequest
+{
+    public function rules(): array
+    {
+        return array_merge(parent::rules(), [
+            'files.*' => [
+                'required',
+                'file',
+                function($attribute, $value, $fail) {
+                    $file = File::query()->where('name', $value->getClientOriginalName())
+                                 ->where('created_by', Auth::id())
+                                 ->where('parent_id', $this->parent_id)
+                                 ->whereNull('deleted_at')
+                                 ->exists();
+                }
+
+                if ($file) {
+                    $fail('File "' . $value->getClientOriginalName() . '" already exists.');
+                }
+            ]
+        ]);
+    }
+}

--- a/drive-app/app/Http/Resources/FileResource.php
+++ b/drive-app/app/Http/Resources/FileResource.php
@@ -7,6 +7,8 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class FileResource extends JsonResource
 {
+    public static $wrap = false;
+
     public function toArray(Request $request): array
     {
         return [

--- a/drive-app/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/drive-app/resources/js/Layouts/AuthenticatedLayout.vue
@@ -5,8 +5,30 @@
     import {onMounted, ref} from "vue";
     import {emitter, FILE_UPLOAD_STARTED} from "@/event-bus.js";
 
+    const dragOver = ref(false);
+
     function uploadFiles(files) {
         console.log(files);
+    }
+
+    function handleDrop(ev) {
+        dragOver.value = false;
+        const files = ev.dataTransfer.files
+
+        console.log(files);
+        if(!files.length) {
+            return;
+        }
+
+        uploadFiles(files);
+    }
+
+    function onDragOver() {
+        dragOver.value = true
+    }
+
+    function onDragLeave() {
+        dragOver.value = false
     }
 
     onMounted(() => {
@@ -17,14 +39,35 @@
 <template>
     <div class="h-screen bg-gray-50 flex w-full gap-4">
         <Navigation class="p-6 bg-zinc-200" />
-        <main class="flex flex-col flex-1 px-4 overflow-hidden p-6">
-            <div class="flex item-center justify-between w-full">
-                <SearchForm />
-                <UserSettingsDropdown />
-            </div>
-            <div class="flex-1 flex flex-col overflow-hidden">
-                <slot />
-            </div>
+        <main @drop.prevent="handleDrop"
+            @dragover.prevent="onDragOver"
+            @dragleave.prevent="onDragLeave"
+            class="flex flex-col flex-1 px-4 overflow-hidden p-6" :class="dragOver ? 'dropzone' : ''">
+
+            <template v-if="dragOver" class="text-gray-500 text-center py-8 text-sm">
+                DROP FILES HERE TO UPLOAD
+            </template>
+            <template v-else>
+                <div class="flex item-center justify-between w-full">
+                    <SearchForm />
+                    <UserSettingsDropdown />
+                </div>
+                <div class="flex-1 flex flex-col overflow-hidden">
+                    <slot />
+                </div>
+            </template>
         </main>
     </div>
 </template>
+
+<style scoped>
+    .dropzone {
+        width: 100%;
+        height: 100%;
+        color: #8d8d8d;
+        border: 2px dashed gray;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+</style>

--- a/drive-app/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/drive-app/resources/js/Layouts/AuthenticatedLayout.vue
@@ -2,6 +2,7 @@
     import Navigation from "@/Components/app/Navigation.vue";
     import SearchForm from "@/Components/app/SearchForm.vue";
     import UserSettingsDropdown from "@/Components/app/UserSettingsDropdown.vue";
+    import {useForm, usePage} from "@inertiajs/vue3";
     import {onMounted, ref} from "vue";
     import {emitter, FILE_UPLOAD_STARTED} from "@/event-bus.js";
 
@@ -14,11 +15,9 @@
     const dragOver = ref(false);
 
     function uploadFiles(files) {
-        console.log(page.props)
         fileUploadForm.parent_id = page.props.folder.id;
-        fileUplaodForm.files = files;
-
-        fileUploadForm.post('route.store');
+        fileUploadForm.files = files;
+        fileUploadForm.post(route('file.store'));
     }
 
     function handleDrop(ev) {

--- a/drive-app/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/drive-app/resources/js/Layouts/AuthenticatedLayout.vue
@@ -5,15 +5,25 @@
     import {onMounted, ref} from "vue";
     import {emitter, FILE_UPLOAD_STARTED} from "@/event-bus.js";
 
+    const page = usePage();
+    const fileUploadForm = useForm({
+        files: [],
+        parent_id: null
+    });
+
     const dragOver = ref(false);
 
     function uploadFiles(files) {
-        console.log(files);
+        console.log(page.props)
+        fileUploadForm.parent_id = page.props.folder.id;
+        fileUplaodForm.files = files;
+
+        fileUploadForm.post('route.store');
     }
 
     function handleDrop(ev) {
         dragOver.value = false;
-        const files = ev.dataTransfer.files
+        const files = ev.dataTransfer.files;
 
         console.log(files);
         if(!files.length) {
@@ -24,11 +34,11 @@
     }
 
     function onDragOver() {
-        dragOver.value = true
+        dragOver.value = true;
     }
 
     function onDragLeave() {
-        dragOver.value = false
+        dragOver.value = false;
     }
 
     onMounted(() => {

--- a/drive-app/routes/web.php
+++ b/drive-app/routes/web.php
@@ -21,6 +21,7 @@ Route::controller(\App\Http\Controllers\FileController::class)
             ->where('folder', '(.*)')
             ->name('myFiles');
         Route::post('/folder/create', 'createFolder')->name('folder.create');
+        Route::post('/file', 'store')->name('file.store');
     });
 
 Route::middleware('auth')->group(function () {


### PR DESCRIPTION
This change introduces basic functionality to allow a user to drop their file into the application. At this stage the file will process via a POST request as if uploading through a form. 

The basic front-end behavior and routing is completed at this stage; the remaining controller functionality to upload a model record will come at a future request. 